### PR TITLE
fix(mockMode): dont load 'viewar-core' in mock mode

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -4,7 +4,10 @@ const { viewarCoreMiddleware } = require('./viewarCore')
 
 const viewArMiddleware = (app) => {
   remoteConsoleMiddleware(app)
-  viewarCoreMiddleware(app)
+
+  if (process.env.WEBPACK_ENV !== 'development_mock') {
+    viewarCoreMiddleware(app)
+  }
 }
 
 

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -4,10 +4,13 @@ const { errorOnUsedPort } = require('./utils')
 const common = require('./env/common.config')
 const core = require('./env/core.config')
 const production = require('./env/production.config')
-const develop = require('./env/develop.config')
 const mock = require('./env/mock.config')
 
 const getMergedConfig = (env) => {
+  process.env.WEBPACK_ENV = env
+
+  const develop = require('./env/develop.config')
+
   if (env === 'production') {
     console.log('using production mode')
     return merge(common.config, production.config)


### PR DESCRIPTION
this is just a workaround viewar/webpack#35
(resolving mode-configs will be refactored in near future)