### PR TITLE
chore(semantic-release): migration to new config key

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branch": "latest",
+  "branches": ["latest"],
   "repositoryUrl": "https://github.com/viewar/webpack",
   "plugins": [
    [


### PR DESCRIPTION
 (`branch` -> `branches`)  
_see: https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file_