### PR TITLE
feat(config): move babels config to babel-loader.options (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # @viewar/webpack
 
 [![Build Status](https://travis-ci.com/viewar/webpack.svg?branch=master)](https://travis-ci.com/viewar/webpack)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=viewar/webpack&identifier=214175000)](https://dependabot.com)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=viewar/webpack&identifier=214175000)](https://dependabot.com)
 [![PRs Welcome][pr-welcome]](http://makeapullrequest.com)<br />
 [![NPM Release](https://img.shields.io/npm/v/%40viewar%2Fwebpack.svg?style=flat)](https://www.npmjs.com/package/%40viewar%2Fwebpack)
 [![Conventional Commits](https://img.shields.io/badge/✔-Conventional%20Commits-blue.svg)](https://conventionalcommits.org)
@@ -22,6 +20,10 @@
 `npm i puppeteer` _- if you use karma_
 
 ### Usage
+
+> **Info:** no need to add babel config to your package.json,  
+> as it is already included in webpacks babel-loader options  
+> **also** removes necessity to install babel plugins and presets
 
 **node - default**
 
@@ -67,6 +69,8 @@ module.exports = (env) => {
 default extensions: `['.js', '.jsx', 'json', '*']`  
 default module paths: `[basename(PATHS.src), 'node_modules']`
 
+_TODO:_ change to aliases to use `~components/*` (see issue #108)
+
 **modify resolve directories**  
 overwrite PATHS.src with `WEBPACK_PATH` (see [constants](#constants)),  
 or add your own 'webpack.config.resolve.js' in your workspace root:
@@ -98,6 +102,8 @@ and get catched server-side to log them in **the terminal**.
 
 The endpoint '/remote-console' is injected per webpack-dev-server's 'before' function:  
 `webpackConfig.devServer.before = viewArMiddleware;`
+
+_TODO:_ see issues #17 and #39
 
 ### errorOnUsedPort()
 

--- a/package.json
+++ b/package.json
@@ -33,34 +33,13 @@
     "config",
     "shared"
   ],
-  "babel": {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "modules": "commonjs",
-          "targets": {
-            "esmodules": true,
-            "browsers": [
-              "> 1%",
-              "last 2 versions",
-              "not ie <= 8"
-            ]
-          }
-        }
-      ],
-      "@babel/preset-react"
-    ],
-    "plugins": [
-      "@babel/plugin-proposal-export-default-from"
-    ]
-  },
   "engines": {
     "node": ">=10.13.0"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "cross-env WEBPACK_PATH=test lint-staged"
+      "pre-commit": "cross-env WEBPACK_PATH=test lint-staged",
+      "pre-push": "npm run test"
     }
   },
   "lint-staged": {
@@ -76,13 +55,18 @@
   "author": "Stefan Friedl <sf@viewar.com>",
   "license": "MIT",
   "dependencies": {
+    "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
+    "@babel/plugin-transform-react-constant-elements": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.6",
     "@babel/preset-react": "^7.8.3",
     "@babel/register": "^7.8.6",
     "@formatjs/intl-pluralrules": "^1.5.2",
     "@formatjs/intl-relativetimeformat": "^4.5.9",
     "babel-loader": "^8.0.6",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "body-parser": "^1.19.0",
     "chai": "^4.2.0",
     "chai-enzyme": "^1.0.0-beta.1",

--- a/src/env/common.config.js
+++ b/src/env/common.config.js
@@ -23,7 +23,42 @@ const getCommonConfig = (env) =>
           {
             test:    /\.(js|jsx)$/,
             exclude: /node_modules/,
-            use:     [ 'babel-loader' ],
+            use:     {
+              loader:  'babel-loader',
+              options: {
+                presets: [
+                  [
+                    '@babel/preset-env',
+                    {
+                      modules:     'auto',
+                      useBuiltIns: 'entry', // uses utils/polyfills
+                      corejs:      3,
+                      targets:     {
+                        node:      'current',
+                        esmodules: true,
+                        browsers:  'last 2 versions',
+                      },
+                    },
+                  ],
+                  '@babel/preset-react',
+                ],
+                plugins: [
+                  '@babel/plugin-transform-runtime',
+                  '@babel/plugin-proposal-export-default-from',
+                  [
+                    '@babel/plugin-proposal-decorators',
+                    {
+                      legacy: true,
+                    },
+                  ],
+                  [ 'transform-class-properties' ],
+                  '@babel/plugin-transform-react-constant-elements',
+                  [
+                    'transform-inline-environment-variables',
+                  ],
+                ],
+              },
+            },
           },
           {
             test: /\.s?css$/,


### PR DESCRIPTION
'no need to add babel config to your package.json'  
also removes necessity to install babel plugins and presets

changes:
* add `useBuiltIns: 'entry'` and `corejs: 3`
* change `targets` to `'last 2 versions'`
* change `module` to `auto`
* add plugins/presets which will needed for other viewar packages

* chore(deps): add babel plugins and presets:  
  * '@babel/plugin-proposal-decorators'
  * '@babel/plugin-transform-react-constant-elements'
  * '@babel/plugin-transform-runtime'
  * 'babel-plugin-transform-class-properties'
  * 'babel-plugin-transform-inline-environment-variables'

* chore(husky): add `"pre-push": "npm run test"`

* feat(config): move babels config to babel-loader.options

* docs: update README

* docs: add info on usage  
  'no need to add babel config to your package.json'